### PR TITLE
Javadoc api bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ dist/
 nbdist/
 nbactions.xml
 nb-configuration.xml
+/bin/

--- a/build.xml
+++ b/build.xml
@@ -201,7 +201,7 @@
         <filename name="**/*.java"/>
         <exclude name="**/*Test.java"/>
       </fileset>
-      <link href="https://docs.oracle.com/javase/8/docs/api/" />
+      <link href="https://docs.oracle.com/en/java/javase/11/docs/api/" />
     </javadoc>
   </target>
 


### PR DESCRIPTION
I fixed the javadoc api reference bug as defined in [https://github.com/MultiCoreDev/redistricting/issues/url]

closes #1 