### PR TITLE
Refactored DistrictTest.java, LocationTest.java, and PartyTest.java t…

### DIFF
--- a/src/swdmt/redistricting/DistrictTest.java
+++ b/src/swdmt/redistricting/DistrictTest.java
@@ -1,8 +1,8 @@
 package swdmt.redistricting;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import org.junit.jupiter.api.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import java.util.HashSet;
 /**

--- a/src/swdmt/redistricting/LocationTest.java
+++ b/src/swdmt/redistricting/LocationTest.java
@@ -1,11 +1,11 @@
 package swdmt.redistricting;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
 import static org.hamcrest.number.OrderingComparison.lessThan;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for objects of type Location.

--- a/src/swdmt/redistricting/PartyTest.java
+++ b/src/swdmt/redistricting/PartyTest.java
@@ -1,8 +1,8 @@
 package swdmt.redistricting;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 /**
  * Tests of Party enum.
  *


### PR DESCRIPTION
…o no longer use Junit4.

Deleted blank line in the import section

Reverted changes to line 36 and line 42

Fixed checkstyle issue.

Junit5 test (#25)

* modified:   src/swdmt/redistricting/DistrictTest.java
	modified:   src/swdmt/redistricting/LocationTest.java
	modified:   src/swdmt/redistricting/PartyTest.java
 Updated the Junit API imports to use JUnit Jupiter, and updated the hamcrest API import for assertThat.

Junit5 test (#26)

* modified:   src/swdmt/redistricting/DistrictTest.java
	modified:   src/swdmt/redistricting/LocationTest.java
	modified:   src/swdmt/redistricting/PartyTest.java
 Updated the Junit API imports to use JUnit Jupiter, and updated the hamcrest API import for assertThat.

* Delete .gitignore

* Revert "	modified:   src/swdmt/redistricting/DistrictTest.java"

This reverts commit 69159237e3045bd453c16e5205f5691548aa7cb5.

* Updated to import Junit5 jupiter and hamcrest Matcher Assert so that all of the tests will no longer use any Junit4 API functionality.